### PR TITLE
12 feature logout do usuário no keycloak

### DIFF
--- a/src/main/java/br/com/marinholab/keycloakxp/configuration/OpenAPIConfiguration.java
+++ b/src/main/java/br/com/marinholab/keycloakxp/configuration/OpenAPIConfiguration.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,7 +27,21 @@ public class OpenAPIConfiguration {
                 .version(properties.getVersion())
                 .contact(contact);
 
-        return new OpenAPI().components(new Components()).info(info);
+        Components components = new Components()
+                .addSecuritySchemes(
+                        "Bearer-Token",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")
+                );
+
+        return new OpenAPI()
+                .components(components)
+                .addSecurityItem(new SecurityRequirement().addList("Bearer-Token"))
+                .info(info);
     }
 
     @Bean

--- a/src/main/java/br/com/marinholab/keycloakxp/core/controller/UserController.java
+++ b/src/main/java/br/com/marinholab/keycloakxp/core/controller/UserController.java
@@ -4,10 +4,12 @@ import br.com.marinholab.keycloakxp.core.model.LoginResponseDTO;
 import br.com.marinholab.keycloakxp.core.model.UserDTO;
 import br.com.marinholab.keycloakxp.core.model.operations.CreateUserForm;
 import br.com.marinholab.keycloakxp.core.model.operations.UserLoginForm;
+import br.com.marinholab.keycloakxp.core.model.operations.UserLogoutForm;
 import br.com.marinholab.keycloakxp.core.service.AuthenticationService;
 import br.com.marinholab.keycloakxp.core.service.CreateUserService;
 import br.com.marinholab.keycloakxp.exception.CreateUserException;
 import br.com.marinholab.keycloakxp.exception.UserAuthenticationException;
+import br.com.marinholab.keycloakxp.exception.UserLogoutException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -74,6 +76,25 @@ public class UserController {
     public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody UserLoginForm form) throws UserAuthenticationException {
         LoginResponseDTO response = this.authenticationService.login(form);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "Ends a user's session in Keycloak.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "The user session was successfully disconnected from Keycloak."
+            ),
+
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Unable to log out the user from Keycloak. This could be an internal issue or invalid credentials."
+            ),
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal Jwt jwt,
+                                       @Valid @RequestBody UserLogoutForm form) throws UserLogoutException {
+        this.authenticationService.logout(form, jwt);
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "Retrieves basic information of the currently authenticated user.")

--- a/src/main/java/br/com/marinholab/keycloakxp/core/model/operations/UserLogoutForm.java
+++ b/src/main/java/br/com/marinholab/keycloakxp/core/model/operations/UserLogoutForm.java
@@ -1,0 +1,6 @@
+package br.com.marinholab.keycloakxp.core.model.operations;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UserLogoutForm(@NotBlank String refreshToken) {
+}

--- a/src/main/java/br/com/marinholab/keycloakxp/core/service/AuthenticationService.java
+++ b/src/main/java/br/com/marinholab/keycloakxp/core/service/AuthenticationService.java
@@ -3,14 +3,19 @@ package br.com.marinholab.keycloakxp.core.service;
 
 import br.com.marinholab.keycloakxp.core.model.LoginResponseDTO;
 import br.com.marinholab.keycloakxp.core.model.operations.UserLoginForm;
+import br.com.marinholab.keycloakxp.core.model.operations.UserLogoutForm;
 import br.com.marinholab.keycloakxp.core.model.properties.KeycloakClientProperties;
 import br.com.marinholab.keycloakxp.core.model.properties.KeycloakProperties;
 import br.com.marinholab.keycloakxp.exception.UserAuthenticationException;
+import br.com.marinholab.keycloakxp.exception.UserLogoutException;
 import br.com.marinholab.keycloakxp.external.KeycloakClient;
 import feign.FeignException;
 import org.keycloak.OAuth2Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -31,14 +36,41 @@ public class AuthenticationService {
     public LoginResponseDTO login(UserLoginForm form) throws UserAuthenticationException {
         try {
             String realm = this.keycloakProperties.getRealm();
-            return this.keycloakClient.authenticate(realm, this.configurePasswordGrantTypeBody(form));
+            return this.keycloakClient.authenticate(realm, this.configureLoginWithPasswordGrantTypeBody(form));
         } catch (FeignException e) {
             LOGGER.error(e.getMessage(), e);
             throw new UserAuthenticationException(form.username());
         }
     }
 
-    private Map<String, ?> configurePasswordGrantTypeBody(UserLoginForm form) {
+    public void logout(UserLogoutForm form, Jwt jwt) throws UserLogoutException {
+        try {
+            String realm = this.keycloakProperties.getRealm();
+            String accessToken = String.format("Bearer %s", jwt.getTokenValue());
+            ResponseEntity<String> response = this.keycloakClient.logout(
+                    realm, accessToken, this.configureLogoutBody(form)
+            );
+
+            if (!response.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
+                LOGGER.error("User logout error: {}", response.getBody());
+                throw new UserLogoutException(jwt.getClaimAsString("preferred_username"));
+            }
+        } catch (FeignException e) {
+            LOGGER.error("User logout error: {}", e.getMessage());
+            throw new UserLogoutException(jwt.getClaimAsString("preferred_username"));
+        }
+    }
+
+    private Map<String, ?> configureLogoutBody(UserLogoutForm form) {
+        KeycloakClientProperties defaultClient = this.keycloakProperties.getDefaultClient();
+        return Map.of(
+                "client_id", defaultClient.getClientId(),
+                "client_secret", defaultClient.getClientSecret(),
+                "refresh_token", form.refreshToken()
+        );
+    }
+
+    private Map<String, ?> configureLoginWithPasswordGrantTypeBody(UserLoginForm form) {
         KeycloakClientProperties defaultClient = this.keycloakProperties.getDefaultClient();
         return Map.of(
                 "username", form.username(),

--- a/src/main/java/br/com/marinholab/keycloakxp/exception/UserLogoutException.java
+++ b/src/main/java/br/com/marinholab/keycloakxp/exception/UserLogoutException.java
@@ -1,0 +1,22 @@
+package br.com.marinholab.keycloakxp.exception;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+public class UserLogoutException extends KeycloakXpException {
+
+    public UserLogoutException(String username) {
+        super(List.of(username));
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getTranslationCode() {
+        return "auth.logout.failed";
+    }
+}

--- a/src/main/java/br/com/marinholab/keycloakxp/external/KeycloakClient.java
+++ b/src/main/java/br/com/marinholab/keycloakxp/external/KeycloakClient.java
@@ -3,8 +3,10 @@ package br.com.marinholab.keycloakxp.external;
 import br.com.marinholab.keycloakxp.core.model.LoginResponseDTO;
 import jakarta.ws.rs.core.MediaType;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.Map;
 
@@ -17,4 +19,13 @@ public interface KeycloakClient {
             produces = MediaType.APPLICATION_JSON
     )
     LoginResponseDTO authenticate(@PathVariable final String realm, Map<String, ?> body);
+
+    @PostMapping(
+            value = "/{realm}/protocol/openid-connect/logout",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED,
+            produces = MediaType.APPLICATION_JSON
+    )
+    ResponseEntity<String> logout(@PathVariable final String realm,
+                                  @RequestHeader("Authorization") String authorization,
+                                  Map<String, ?> body);
 }

--- a/src/main/resources/internationalization/messages.properties
+++ b/src/main/resources/internationalization/messages.properties
@@ -1,2 +1,3 @@
 error.internal=An internal error has occurred. Please try again later.
 auth.login.failed=Unable to authenticate user {0}. Please check your credentials and try again.
+auth.logout.failed=Unable to log out user {0}. Please check your information and try again.

--- a/src/main/resources/internationalization/messages_br.properties
+++ b/src/main/resources/internationalization/messages_br.properties
@@ -1,2 +1,3 @@
 error.internal=Ocorreu um erro interno. Tente novamente mais tarde.
 auth.login.failed=Não foi possível autenticar o usuário {0}. Verifique suas credenciais e tente novamente.
+auth.logout.failed=Não foi possível realizar o logout do usuário {0}. Por favor, verifique as informações e tente novamente.

--- a/src/main/resources/internationalization/messages_es.properties
+++ b/src/main/resources/internationalization/messages_es.properties
@@ -1,2 +1,3 @@
 error.internal=Se ha producido un error interno. Inténtalo de nuevo más tarde.
 auth.login.failed=No se puede autenticar al usuario {0}. Verifique sus credenciales y vuelva a intentarlo.
+auth.logout.failed=No se puede cerrar la sesión del usuario {0}. Verifique su información y vuelva a intentarlo.

--- a/src/test/java/br/com/marinholab/keycloakxp/core/model/operations/UserLogoutFormTest.java
+++ b/src/test/java/br/com/marinholab/keycloakxp/core/model/operations/UserLogoutFormTest.java
@@ -1,0 +1,17 @@
+package br.com.marinholab.keycloakxp.core.model.operations;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserLogoutFormTest {
+
+    @Test
+    @DisplayName("Should return a valid instance of user logout form")
+    void shouldReturnValidInstanceOfUserLogoutForm() {
+        String refreshToken = "refreshToken";
+        UserLogoutForm form = new UserLogoutForm(refreshToken);
+        assertEquals(refreshToken, form.refreshToken());
+    }
+}

--- a/src/test/java/br/com/marinholab/keycloakxp/core/service/AuthenticationServiceTest.java
+++ b/src/test/java/br/com/marinholab/keycloakxp/core/service/AuthenticationServiceTest.java
@@ -1,9 +1,11 @@
 package br.com.marinholab.keycloakxp.core.service;
 
 import br.com.marinholab.keycloakxp.core.model.operations.UserLoginForm;
+import br.com.marinholab.keycloakxp.core.model.operations.UserLogoutForm;
 import br.com.marinholab.keycloakxp.core.model.properties.KeycloakClientProperties;
 import br.com.marinholab.keycloakxp.core.model.properties.KeycloakProperties;
 import br.com.marinholab.keycloakxp.exception.UserAuthenticationException;
+import br.com.marinholab.keycloakxp.exception.UserLogoutException;
 import br.com.marinholab.keycloakxp.external.KeycloakClient;
 import feign.FeignException;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +14,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.jwt.Jwt;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -51,6 +57,73 @@ class AuthenticationServiceTest {
                 UserAuthenticationException.class,
                 () -> this.authenticationService.login(formAsMock)
         );
+    }
+
+    @Test
+    @DisplayName("Should throw exception when unexpected error occurs in Keycloak logout request")
+    void shouldThrowExceptionWhenUnexpectedErrorOccursInKeycloakLogoutRequest() {
+        String refreshToken = "refreshToken";
+        UserLogoutForm formAsMock = mock(UserLogoutForm.class);
+        KeycloakClientProperties keycloakClientPropertiesAsMock = mock(KeycloakClientProperties.class);
+        Jwt jwtAsMock = mock(Jwt.class);
+
+        when(formAsMock.refreshToken()).thenReturn(refreshToken);
+        when(this.keycloakProperties.getRealm()).thenReturn("realm");
+        when(jwtAsMock.getTokenValue()).thenReturn("tokenValue");
+        when(this.keycloakProperties.getDefaultClient()).thenReturn(keycloakClientPropertiesAsMock);
+        when(keycloakClientPropertiesAsMock.getClientId()).thenReturn("clientId");
+        when(keycloakClientPropertiesAsMock.getClientSecret()).thenReturn("secret");
+        when(this.keycloakClient.logout(anyString(), anyString(), anyMap())).thenThrow(FeignException.class);
+        when(jwtAsMock.getClaimAsString("preferred_username")).thenReturn("root");
+
+        assertThrows(
+                UserLogoutException.class,
+                () -> this.authenticationService.logout(formAsMock, jwtAsMock)
+        );
+    }
+
+    @Test
+    @DisplayName("Should throw exception when status on logout response from keycloak is not 204")
+    void shouldThrowExceptionWhenStatusOnLogoutResponseFromKeycloakIsNot204() {
+        String refreshToken = "refreshToken";
+        UserLogoutForm formAsMock = mock(UserLogoutForm.class);
+        KeycloakClientProperties keycloakClientPropertiesAsMock = mock(KeycloakClientProperties.class);
+        Jwt jwtAsMock = mock(Jwt.class);
+        ResponseEntity<String> response = ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Bad request");
+
+        when(formAsMock.refreshToken()).thenReturn(refreshToken);
+        when(this.keycloakProperties.getRealm()).thenReturn("realm");
+        when(jwtAsMock.getTokenValue()).thenReturn("tokenValue");
+        when(this.keycloakProperties.getDefaultClient()).thenReturn(keycloakClientPropertiesAsMock);
+        when(keycloakClientPropertiesAsMock.getClientId()).thenReturn("clientId");
+        when(keycloakClientPropertiesAsMock.getClientSecret()).thenReturn("secret");
+        when(this.keycloakClient.logout(anyString(), anyString(), anyMap())).thenReturn(response);
+        when(jwtAsMock.getClaimAsString("preferred_username")).thenReturn("root");
+
+        assertThrows(
+                UserLogoutException.class,
+                () -> this.authenticationService.logout(formAsMock, jwtAsMock)
+        );
+    }
+
+    @Test
+    @DisplayName("Should do nothing when logout successfully occurs in Keycloak")
+    void shouldDoNothingWhenLogoutSuccessfullyOccursInKeycloak() {
+        String refreshToken = "refreshToken";
+        UserLogoutForm formAsMock = mock(UserLogoutForm.class);
+        KeycloakClientProperties keycloakClientPropertiesAsMock = mock(KeycloakClientProperties.class);
+        Jwt jwtAsMock = mock(Jwt.class);
+        ResponseEntity<String> response = ResponseEntity.status(HttpStatus.NO_CONTENT).body("Success!");
+
+        when(formAsMock.refreshToken()).thenReturn(refreshToken);
+        when(this.keycloakProperties.getRealm()).thenReturn("realm");
+        when(jwtAsMock.getTokenValue()).thenReturn("tokenValue");
+        when(this.keycloakProperties.getDefaultClient()).thenReturn(keycloakClientPropertiesAsMock);
+        when(keycloakClientPropertiesAsMock.getClientId()).thenReturn("clientId");
+        when(keycloakClientPropertiesAsMock.getClientSecret()).thenReturn("secret");
+        when(this.keycloakClient.logout(anyString(), anyString(), anyMap())).thenReturn(response);
+
+        assertDoesNotThrow(() -> this.authenticationService.logout(formAsMock, jwtAsMock));
     }
 
 }

--- a/src/test/java/br/com/marinholab/keycloakxp/exception/UserLogoutExceptionTest.java
+++ b/src/test/java/br/com/marinholab/keycloakxp/exception/UserLogoutExceptionTest.java
@@ -1,0 +1,19 @@
+package br.com.marinholab.keycloakxp.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class UserLogoutExceptionTest {
+
+    @Test
+    @DisplayName("Should return a valid instance of exception with args constructor")
+    void shouldReturnValidInstanceOfExceptionWithArgsConstructor() {
+        UserLogoutException exception = new UserLogoutException("root");
+        assertEquals(1, exception.getArgsAsArray().length);
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getHttpStatus());
+        assertEquals("auth.logout.failed", exception.getTranslationCode());
+    }
+}


### PR DESCRIPTION
🧪FIXES/FEATURES:

* Configuração no Swagger para permitir adicionar o cabeçalho de autorização, permitindo utilizar endpoints protegidos;
* Configuração do endpoint de logout do Keycloak;
* Configuração de novas traduções para a internacionalização de exceções;
* Testes unitários para a nova operação de logout;